### PR TITLE
Add GitHub Actions workflow to run tests on PR and master push

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,29 @@
+name: CI
+
+on:
+  push:
+    branches: [master]
+  pull_request:
+    branches: [master]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v3
+
+    - name: Set up Python
+      uses: actions/setup-python@v4
+      with:
+        python-version: '3.10'
+
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install -r requirements.txt || pip install -r service/requirements.txt || pip install .
+
+    - name: Run tests with pytest
+      run: |
+        pytest tests --cov=service --cov-report=xml


### PR DESCRIPTION
Adds a GitHub Actions workflow that runs pytest on PRs and pushes to master.

Based on the user story: 
"As a Developer
I need to automate running unit tests via GitHub Actions
So that all pull requests and master pushes are validated by automated tests"