### PR TITLE
Adds Kubernetes YAML files (deployment, service, ingress) for deployi…

### DIFF
--- a/k8s/deployment.yaml
+++ b/k8s/deployment.yaml
@@ -1,0 +1,39 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: inventory
+  labels:
+    app: inventory
+spec:
+  replicas: 1
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxSurge: 2
+      maxUnavailable: 0
+  selector:
+    matchLabels:
+      app: inventory
+  template:
+    metadata:
+      labels:
+        app: inventory
+    spec:
+      restartPolicy: Always
+      containers:
+      - name: inventory
+        image: cluster-registry:5000/inventory:1.0  # ← change this if needed
+        imagePullPolicy: IfNotPresent
+        ports:
+        - containerPort: 8080
+          protocol: TCP
+        env:
+        - name: DATABASE_URI
+          value: postgresql://postgres:postgres@postgres:5432/postgres
+        resources:
+          limits:
+            cpu: "0.25"
+            memory: "64Mi"
+          requests:
+            cpu: "0.10"
+            memory: "32Mi"

--- a/k8s/ingress.yaml
+++ b/k8s/ingress.yaml
@@ -1,0 +1,17 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: inventory
+  annotations:
+    nginx.ingress.kubernetes.io/rewrite-target: /
+spec:
+  rules:
+    - http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: inventory
+                port:
+                  number: 8080

--- a/k8s/service.yaml
+++ b/k8s/service.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: inventory
+spec:
+  type: ClusterIP
+  selector:
+    app: inventory
+  ports:
+    - name: http
+      protocol: TCP
+      port: 8080
+      targetPort: 8080

--- a/service/routes.py
+++ b/service/routes.py
@@ -272,7 +272,7 @@ def update_stock(inventory_id):
         app.logger.error("Missing quantity in request")
         return jsonify({"error": "Missing quantity"}), status.HTTP_400_BAD_REQUEST
 
-    new_quantity = data["quantity"]
+    new_quantity = int(data["quantity"])
     inventory.quantity = new_quantity
     app.logger.info("Updating quantity to %s", new_quantity)
 


### PR DESCRIPTION
Adds Kubernetes YAML files for deploying the inventory microservice. This includes:

deployment.yaml: Defines the deployment config for the Flask app
service.yaml: Exposes the deployment via a ClusterIP service
ingress.yaml: Sets up ingress rules for external access to the app

PLEASE NOTE: in deployment.yaml file, the current deployment uses the following image reference:
"image: cluster-registry:5000/inventory:1.0"
However, this image has not been built yet. 

Acceptance Criteria Met:
✅ Manifest files are created and located under /k8s/
✅ Microservice is configured for deployment and accessible via ingress