### PR TITLE
Enable webhook-triggered pipeline by updating README and fixing Tekton clone task workspace

### DIFF
--- a/k8s/postgres/README.md
+++ b/k8s/postgres/README.md
@@ -123,3 +123,4 @@ kubectl delete -f .
 ```
 
 Note: If you want to preserve your data, you should back it up before cleaning up.
+<!-- Trigger webhook test -->

--- a/tekton/tasks/clone-task.yaml
+++ b/tekton/tasks/clone-task.yaml
@@ -1,0 +1,12 @@
+apiVersion: tekton.dev/v1
+kind: Task
+metadata:
+  name: clone-repo
+spec:
+  workspaces:
+    - name: output
+  steps:
+    - name: clone
+      image: alpine/git
+      script: |
+        git clone https://github.com/CSCI-GA-2820-SP25-001/inventory.git /workspace/output


### PR DESCRIPTION
This PR updates the README to test if the GitHub webhook correctly triggers the Tekton pipeline via the EventListener.